### PR TITLE
Revisions to the visitor-by-day api, and removing comma separation instructions (because it's broken)

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -299,7 +299,7 @@ visitors, total visitors, total unique visitors, and unique daily visitors. New 
 URI Parameters| Description                                                | Example
 ------------  | -----------------------------------------------------------| ---------------------------------------
 ACCESS_TOKEN  | the token generated in oauth                               | 0281a718b3a033f01dda311fab7cfe59066bbb73
-ID            | venue/group id                                             | 450007,45008
+ID            | venue/group id                                             | 450007
 START         | Unix timestamp representing the first day of data returned | 1425358800
 LENGTH        | Number of days since start date to return                  | 7
 TYPE          | What type of ID is being submitted, venue (V) or group (G) | V
@@ -380,7 +380,7 @@ hardware MAC Address.
 URI Parameters| Description                                                | Example
 ------------  | -----------------------------------------------------------| ---------------------------------------
 ACCESS_TOKEN  | the token generated in oauth                               | 0281a718b3a033f01dda311fab7cfe59066bbb73
-ID            | venue/group id, comma separated, string                    | 450007,45008
+ID            | venue/group id                                             | 450007
 START         | Unix timestamp representing the first day of data returned | 1425358800
 LENGTH        | Number of days since start date to return                  | 7
 TYPE          | What type of ID is being submitted, venue (V) or group (G) | V
@@ -446,7 +446,7 @@ criteria around RSSI and FRAMES to be counted as Walk-By (vs Visitors or Noise).
 URI Parameters| Description                                                | Example
 ------------  | -----------------------------------------------------------| ---------------------------------------
 ACCESS_TOKEN  | the token generated in oauth                               | 0281a718b3a033f01dda311fab7cfe59066bbb73
-ID            | venue/group id, comma separated, string                    | 450007,45008
+ID            | venue/group id                                             | 450007
 START         | Unix timestamp representing the first day of data returned | 1425358800
 LENGTH        | Number of days since start date to return                  | 7
 TYPE          | What type of ID is being submitted, venue (V) or group (G) | V
@@ -498,7 +498,7 @@ out by day.
 URI Parameters| Description                                                | Example
 ------------  | -----------------------------------------------------------| ---------------------------------------
 ACCESS_TOKEN  | the token generated in oauth                               | 0281a718b3a033f01dda311fab7cfe59066bbb73
-ID            | venue/group id, comma separated, string                    | 450007,45008
+ID            | venue/group id                                             | 450007
 START         | Unix timestamp representing the first day of data returned | 1425358800
 LENGTH        | Number of days since start date to return                  | 7
 TYPE          | What type of ID is being submitted, venue (V) or group (G) | V
@@ -604,7 +604,7 @@ and >12h.
 URI Parameters| Description                                                | Example
 ------------  | -----------------------------------------------------------| ---------------------------------------
 ACCESS_TOKEN  | the token generated in oauth                               | 0281a718b3a033f01dda311fab7cfe59066bbb73
-ID            | venue/group id, comma separated, string                    | 450007,45008
+ID            | venue/group id                                             | 450007
 START         | Unix timestamp representing the first day of data returned | 1425358800
 LENGTH        | Number of days since start date to return                  | 7
 TYPE          | What type of ID is being submitted, venue (V) or group (G) | V
@@ -713,7 +713,7 @@ period specified.
 URI Parameters| Description                                                | Example
 ------------  | -----------------------------------------------------------| ---------------------------------------
 ACCESS_TOKEN  | the token generated in oauth                               | 0281a718b3a033f01dda311fab7cfe59066bbb73
-ID            | venue/group id, comma separated, string                    | 450007,45008
+ID            | venue/group id                                             | 450007
 START         | Unix timestamp representing the first day of data returned | 1425358800
 LENGTH        | Number of days since start date to return                  | 7
 TYPE          | What type of ID is being submitted, venue (V) or group (G) | V
@@ -801,8 +801,9 @@ metric returns data for the single day specified in the request, ie.
 URI Parameters| Description                                                | Example
 ------------  | -----------------------------------------------------------| ---------------------------------------
 ACCESS_TOKEN  | the token generated in oauth                               | 0281a718b3a033f01dda311fab7cfe59066bbb73
-ID            | venue/group id, comma separated, string                    | 450007,45008
+ID            | venue/group id                                             | 450007
 START         | Unix timestamp representing the day of data returned       | 1425358800
+LENGTH        | Number of days since start date to return                  | 7
 TYPE          | What type of ID is being submitted, venue (V) or group (G) | V
 
 ## Known Visitors
@@ -887,7 +888,7 @@ in other end-points.
 URI Parameters| Description                                                | Example
 ------------  | -----------------------------------------------------------| ---------------------------------------
 ACCESS_TOKEN  | the token generated in oauth                               | 0281a718b3a033f01dda311fab7cfe59066bbb73
-ID            | venue/group id, comma separated, string                    | 450007,45008
+ID            | venue/group id                                             | 450007
 START         | Unix timestamp representing the day of data returned       | 1425358800
 TYPE          | What type of ID is being submitted, venue (V) or group (G) | V
 
@@ -974,7 +975,7 @@ the Yelp WiFi network.
 URI Parameters| Description                                                | Example
 ------------  | -----------------------------------------------------------| ---------------------------------------
 ACCESS_TOKEN  | the token generated in oauth                               | 0281a718b3a033f01dda311fab7cfe59066bbb73
-ID            | venue/group id, comma separated, string                    | 450007,45008
+ID            | venue/group id                                             | 450007
 START         | Unix timestamp representing the day of data returned       | 1425358800
 TYPE          | What type of ID is being submitted, venue (V) or group (G) | V
 
@@ -1057,8 +1058,8 @@ barcode_value      | The content of the barcode, disregard if barcode is not use
 bar_code_type      | The type of barcode displayed, disregard if barcode is not used                                     | UFA-1
 email_logo         | The logo in the email, dispayed at the top of the message                                           | http://imgur.com/as123sa
 email_subject      | The subject line of the email                                                                       | HELLO WORLD
-email_body         | The content of the email                                                                            | Welcome to Turnstyle
-email_from         | The from line of the email                                                                          | Turnstyle Solutions
+email_body         | The content of the email                                                                            | Welcome to Yelp WiFi
+email_from         | The from line of the email                                                                          | Yelp WiFi
 email_html_bool    | Indicator if the email has html content (recommended), boolean, default enabled                     | True
 tweets             | Content of the tweet                                                                                | Hello @World
 sms_message        | Content of the text message                                                                         | Hello World
@@ -1081,7 +1082,7 @@ a POST request is made to the URL. If you would like to enable functionality,
 please contact support@yelpwifi.com
 
 Note: Not all of the user properties will be present, depending on what method
-the user used to authenticate, and what info they granted Turnstyle to have access
+the user used to authenticate, and what info they granted Yelp WiFi to have access
 to.
 
 ### Response
@@ -1502,7 +1503,7 @@ Property     | Description                                     | Required
 ------------ | ------------------------------------------------| ------------
 access_token | The token generated in oauth                    | Yes
 user_id      | The visitors Yelp WiFi ID (or wifi_uid)         | Yes
-first_name   | User's first name                               | No (
+first_name   | User's first name                               | No 
 last_name    | User's last name                                | No
 email        | User's email                                    | Yes
 phone        | User's phone number                             | No

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -234,52 +234,62 @@ Content-Type:application/json
 
 ```json
 {
-  "start": [
-    "1425358800"
-  ],
-  "length": 6,
-  "request_time": 0.030459880828857,
-  "has_data": true,
-  "data": {
-    "4234970": {
-      "1425358800": [
-        {
-          "key": "2015-03-03",
-          "values": {
-            "total": 77,
-            "new": 20
-          }
-        },
-        {
-          "key": "2015-03-04",
-          "values": {
-            "total": 4,
-            "new": 1
-          }
-        },
-        {
-          "key": "2015-03-05",
-          "values": {
-            "total": 0,
-            "new": 0
-          }
-        },
-        {
-          "key": "2015-03-06",
-          "values": {
-            "total": 54,
-            "new": 16
-          }
+    "start": [
+        "1514764800"
+    ],
+    "length": 3,
+    "error_margin": [
+        13
+    ],
+    "request_time": 47.448456,
+    "has_data": true,
+    "data": {
+        "V1234567": {
+            "1514764800": [
+                {
+                    "key": "2018-01-01",
+                    "values": {
+                        "total": 45,
+                        "new": 30,
+                        "unique": 228,
+                        "unique_daily": 45
+                    }
+                },
+                {
+                    "key": "2018-01-02",
+                    "values": {
+                        "total": 42,
+                        "new": 22,
+                        "unique": 0,
+                        "unique_daily": 42
+                    }
+                },
+                {
+                    "key": "2018-01-03",
+                    "values": {
+                        "total": 73,
+                        "new": 48,
+                        "unique": 0,
+                        "unique_daily": 73
+                    }
+                },
+                {
+                    "key": "2018-01-04",
+                    "values": {
+                        "total": 75,
+                        "new": 28,
+                        "unique": 0,
+                        "unique_daily": 75
+                    }
+                }
+            ]
         }
-      ]
     }
-  }
 }
 ```
 
-The number of visitors seen at a particular venue. This is broken out by new
-visitors and total visitors. New visitors are visitors who have never been
-seen at the venue previously.
+This API provides the number of visitors seen at a particular venue or group for a given time period. This is separated by new
+visitors, total visitors, total unique visitors, and unique daily visitors. New visitors are visitors who have not previously been seen at the venue. The unique value on the first day represents the total number of unique visitors for the given time period. Unique daily represents the individual visitors for the day. The value for unique minus the sum of unique_daily represents the number of repeat visitors for the given date range.
 
 
 ### HTTPS Request
@@ -289,7 +299,7 @@ seen at the venue previously.
 URI Parameters| Description                                                | Example
 ------------  | -----------------------------------------------------------| ---------------------------------------
 ACCESS_TOKEN  | the token generated in oauth                               | 0281a718b3a033f01dda311fab7cfe59066bbb73
-ID            | venue/group id, comma separated, string                    | 450007,45008
+ID            | venue/group id                                             | 450007,45008
 START         | Unix timestamp representing the first day of data returned | 1425358800
 LENGTH        | Number of days since start date to return                  | 7
 TYPE          | What type of ID is being submitted, venue (V) or group (G) | V

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -289,7 +289,7 @@ Content-Type:application/json
 ```
 
 This API provides the number of visitors seen at a particular venue or group for a given time period. This is separated by new
-visitors, total visitors, total unique visitors, and unique daily visitors. New visitors are visitors who have not previously been seen at the venue. The unique value on the first day represents the total number of unique visitors for the given time period. Unique daily represents the individual visitors for the day. The value for unique minus the sum of unique_daily represents the number of repeat visitors for the given date range.
+visitors, total visitors, total unique visitors, and unique daily visitors. New visitors are visitors who have not previously been seen at the venue. The `unique` value that's provided on the first day represents the total number of unique visitors for the given time period. Unique daily represents the individual visitors for the day. The value for `unique` minus the sum of `unique_daily` represents the number of repeat visitors for the given date range.
 
 
 ### HTTPS Request


### PR DESCRIPTION
updated visitor by day api to reflect new payload structure, removed the copy indicating that comma separated venues/groups works (because it no longer does). Revising copy for grammar and specificity. Additional polish.